### PR TITLE
CET 572 fix github team API deprecation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.kohsuke</groupId>
   <artifactId>cortexapps-github-api</artifactId>
-  <version>1.134-SNAPSHOT</version>
+  <version>1.135-SNAPSHOT</version>
   <name>GitHub API for Java</name>
   <url>https://github-api.kohsuke.org/</url>
   <description>GitHub API for Java</description>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.kohsuke</groupId>
   <artifactId>cortexapps-github-api</artifactId>
-  <version>1.133-SNAPSHOT</version>
+  <version>1.134-SNAPSHOT</version>
   <name>GitHub API for Java</name>
   <url>https://github-api.kohsuke.org/</url>
   <description>GitHub API for Java</description>

--- a/src/main/java/org/kohsuke/github/GHCommit.java
+++ b/src/main/java/org/kohsuke/github/GHCommit.java
@@ -470,7 +470,13 @@ public class GHCommit {
         return owner.root.createRequest()
                 .withPreview(GROOT)
                 .withUrlPath(String.format("/repos/%s/%s/commits/%s/pulls", owner.getOwnerName(), owner.getName(), sha))
-                .toIterable(GHPullRequest[].class, item -> item.wrapUp(owner));
+                .toIterable(GHPullRequest[].class, item -> {
+                    try {
+                        item.wrapUp(owner);
+                    } catch (IOException e) {
+                        throw new GHException("Failed to list pull requests", e);
+                    }
+                });
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHEventPayload.java
+++ b/src/main/java/org/kohsuke/github/GHEventPayload.java
@@ -107,7 +107,7 @@ public class GHEventPayload extends GitHubInteractiveObject {
         return installation;
     }
 
-    void wrapUp(GitHub root) {
+    void wrapUp(GitHub root) throws IOException {
         this.root = root;
         if (sender != null) {
             sender.wrapUp(root);
@@ -191,7 +191,7 @@ public class GHEventPayload extends GitHubInteractiveObject {
         }
 
         @Override
-        void wrapUp(GitHub root) {
+        void wrapUp(GitHub root) throws IOException {
             super.wrapUp(root);
             if (checkRun == null)
                 throw new IllegalStateException(
@@ -225,7 +225,7 @@ public class GHEventPayload extends GitHubInteractiveObject {
         }
 
         @Override
-        void wrapUp(GitHub root) {
+        void wrapUp(GitHub root) throws IOException {
             super.wrapUp(root);
             if (checkSuite == null)
                 throw new IllegalStateException(
@@ -260,7 +260,7 @@ public class GHEventPayload extends GitHubInteractiveObject {
         };
 
         @Override
-        void wrapUp(GitHub root) {
+        void wrapUp(GitHub root) throws IOException {
             super.wrapUp(root);
             if (getInstallation() == null) {
                 throw new IllegalStateException(
@@ -321,7 +321,7 @@ public class GHEventPayload extends GitHubInteractiveObject {
         }
 
         @Override
-        void wrapUp(GitHub root) {
+        void wrapUp(GitHub root) throws IOException {
             super.wrapUp(root);
             if (getInstallation() == null) {
                 throw new IllegalStateException(
@@ -400,7 +400,7 @@ public class GHEventPayload extends GitHubInteractiveObject {
         }
 
         @Override
-        void wrapUp(GitHub root) {
+        void wrapUp(GitHub root) throws IOException {
             super.wrapUp(root);
             if (pullRequest == null)
                 throw new IllegalStateException(
@@ -445,7 +445,7 @@ public class GHEventPayload extends GitHubInteractiveObject {
         }
 
         @Override
-        void wrapUp(GitHub root) {
+        void wrapUp(GitHub root) throws IOException {
             super.wrapUp(root);
             if (review == null)
                 throw new IllegalStateException(
@@ -493,7 +493,7 @@ public class GHEventPayload extends GitHubInteractiveObject {
         }
 
         @Override
-        void wrapUp(GitHub root) {
+        void wrapUp(GitHub root) throws IOException {
             super.wrapUp(root);
             if (comment == null)
                 throw new IllegalStateException(
@@ -563,7 +563,7 @@ public class GHEventPayload extends GitHubInteractiveObject {
         }
 
         @Override
-        void wrapUp(GitHub root) {
+        void wrapUp(GitHub root) throws IOException {
             super.wrapUp(root);
             GHRepository repository = getRepository();
             if (repository != null) {
@@ -625,7 +625,7 @@ public class GHEventPayload extends GitHubInteractiveObject {
         }
 
         @Override
-        void wrapUp(GitHub root) {
+        void wrapUp(GitHub root) throws IOException {
             super.wrapUp(root);
             GHRepository repository = getRepository();
             if (repository != null) {
@@ -668,7 +668,7 @@ public class GHEventPayload extends GitHubInteractiveObject {
         }
 
         @Override
-        void wrapUp(GitHub root) {
+        void wrapUp(GitHub root) throws IOException {
             super.wrapUp(root);
             GHRepository repository = getRepository();
             if (repository != null) {
@@ -795,7 +795,7 @@ public class GHEventPayload extends GitHubInteractiveObject {
         }
 
         @Override
-        void wrapUp(GitHub root) {
+        void wrapUp(GitHub root) throws IOException {
             super.wrapUp(root);
             GHRepository repository = getRepository();
             if (repository != null) {
@@ -855,7 +855,7 @@ public class GHEventPayload extends GitHubInteractiveObject {
         }
 
         @Override
-        void wrapUp(GitHub root) {
+        void wrapUp(GitHub root) throws IOException {
             super.wrapUp(root);
             GHRepository repository = getRepository();
             if (repository != null) {
@@ -895,7 +895,7 @@ public class GHEventPayload extends GitHubInteractiveObject {
         }
 
         @Override
-        void wrapUp(GitHub root) {
+        void wrapUp(GitHub root) throws IOException {
             super.wrapUp(root);
             forkee.wrap(root);
         }
@@ -1317,7 +1317,7 @@ public class GHEventPayload extends GitHubInteractiveObject {
         }
 
         @Override
-        void wrapUp(GitHub root) {
+        void wrapUp(GitHub root) throws IOException {
             super.wrapUp(root);
             if (state == null) {
                 throw new IllegalStateException(
@@ -1405,7 +1405,7 @@ public class GHEventPayload extends GitHubInteractiveObject {
         }
 
         @Override
-        void wrapUp(GitHub root) {
+        void wrapUp(GitHub root) throws IOException {
             super.wrapUp(root);
             if (workflowRun == null || workflow == null) {
                 throw new IllegalStateException(

--- a/src/main/java/org/kohsuke/github/GHPullRequest.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequest.java
@@ -72,12 +72,12 @@ public class GHPullRequest extends GHIssue implements Refreshable {
     private GHUser[] requested_reviewers;
     private GHTeam[] requested_teams;
 
-    GHPullRequest wrapUp(GHRepository owner) {
+    GHPullRequest wrapUp(GHRepository owner) throws IOException {
         this.wrap(owner);
         return wrapUp(owner.root);
     }
 
-    GHPullRequest wrapUp(GitHub root) {
+    GHPullRequest wrapUp(GitHub root) throws IOException {
         if (owner != null)
             owner.wrap(root);
         if (base != null)
@@ -89,7 +89,7 @@ public class GHPullRequest extends GHIssue implements Refreshable {
         if (requested_reviewers != null)
             GHUser.wrap(requested_reviewers, root);
         if (requested_teams != null)
-            GHTeam.wrapUp(requested_teams, root);
+            GHTeam.wrapUp(requested_teams, this);
         return this;
     }
 

--- a/src/main/java/org/kohsuke/github/GHPullRequest.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequest.java
@@ -89,7 +89,7 @@ public class GHPullRequest extends GHIssue implements Refreshable {
         if (requested_reviewers != null)
             GHUser.wrap(requested_reviewers, root);
         if (requested_teams != null)
-            GHTeam.wrapUp(requested_teams, this);
+            GHTeam.wrapUp(requested_teams, root);
         return this;
     }
 

--- a/src/main/java/org/kohsuke/github/GHPullRequestQueryBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestQueryBuilder.java
@@ -1,5 +1,7 @@
 package org.kohsuke.github;
 
+import java.io.IOException;
+
 import static org.kohsuke.github.internal.Previews.SHADOW_CAT;
 
 /**
@@ -90,6 +92,12 @@ public class GHPullRequestQueryBuilder extends GHQueryBuilder<GHPullRequest> {
     public PagedIterable<GHPullRequest> list() {
         return req.withPreview(SHADOW_CAT)
                 .withUrlPath(repo.getApiTailUrl("pulls"))
-                .toIterable(GHPullRequest[].class, item -> item.wrapUp(repo));
+                .toIterable(GHPullRequest[].class, item -> {
+                    try {
+                        item.wrapUp(repo);
+                    } catch (IOException e) {
+                        throw new GHException("Failed to list pull requests", e);
+                    }
+                });
     }
 }

--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -3147,7 +3147,7 @@ public class GHRepository extends GHObject {
      * @param encryptedValue
      *            The encrypted value for this secret
      * @param publicKeyId
-     *             The id of the Public Key used to encrypt this secret
+     *            The id of the Public Key used to encrypt this secret
      * @throws IOException
      *             the io exception
      */

--- a/src/main/java/org/kohsuke/github/GHTeam.java
+++ b/src/main/java/org/kohsuke/github/GHTeam.java
@@ -57,7 +57,11 @@ public class GHTeam extends GHObject implements Refreshable {
 
     static GHTeam[] wrapUp(GHTeam[] teams, GHPullRequest owner) {
         for (GHTeam t : teams) {
-            t.root = owner.root;
+            try {
+                t.wrapUp(owner.root.getOrganization(owner.getRepository().getOwnerName()));
+            } catch (IOException e) {
+                throw new GHException("Failed to get organization that owns the repository for the PR", e);
+            }
         }
         return teams;
     }

--- a/src/main/java/org/kohsuke/github/GHTeam.java
+++ b/src/main/java/org/kohsuke/github/GHTeam.java
@@ -55,9 +55,13 @@ public class GHTeam extends GHObject implements Refreshable {
         return wrapUp(organization);
     }
 
-    static GHTeam[] wrapUp(GHTeam[] teams, GitHub root) {
+    static GHTeam[] wrapUp(GHTeam[] teams, GHPullRequest owner) throws IOException {
+        if (teams.length == 0) {
+            return teams;
+        }
+        GHOrganization org = owner.root.getOrganization(owner.getRepository().getOwnerName());
         for (GHTeam t : teams) {
-            t.wrapUp(root);
+            t.wrapUp(org);
         }
         return teams;
     }

--- a/src/main/java/org/kohsuke/github/GHTeam.java
+++ b/src/main/java/org/kohsuke/github/GHTeam.java
@@ -55,13 +55,9 @@ public class GHTeam extends GHObject implements Refreshable {
         return wrapUp(organization);
     }
 
-    static GHTeam[] wrapUp(GHTeam[] teams, GHPullRequest owner) {
+    static GHTeam[] wrapUp(GHTeam[] teams, GitHub root) {
         for (GHTeam t : teams) {
-            try {
-                t.wrapUp(owner.root.getOrganization(owner.getRepository().getOwnerName()));
-            } catch (IOException e) {
-                throw new GHException("Failed to get organization that owns the repository for the PR", e);
-            }
+            t.wrapUp(root);
         }
         return teams;
     }

--- a/src/main/java/org/kohsuke/github/GHTeam.java
+++ b/src/main/java/org/kohsuke/github/GHTeam.java
@@ -221,7 +221,7 @@ public class GHTeam extends GHObject implements Refreshable {
      */
     public boolean hasMember(GHUser user) {
         try {
-            root.createRequest().withUrlPath("/teams/" + getId() + "/members/" + user.getLogin()).send();
+            root.createRequest().withUrlPath(api("/memberships/" + user.getLogin())).send();
             return true;
         } catch (IOException ignore) {
             return false;
@@ -298,7 +298,7 @@ public class GHTeam extends GHObject implements Refreshable {
      *             the io exception
      */
     public void remove(GHUser u) throws IOException {
-        root.createRequest().method("DELETE").withUrlPath(api("/members/" + u.getLogin())).send();
+        root.createRequest().method("DELETE").withUrlPath(api("/memberships/" + u.getLogin())).send();
     }
 
     /**
@@ -354,7 +354,7 @@ public class GHTeam extends GHObject implements Refreshable {
     }
 
     private String api(String tail) {
-        return "/teams/" + getId() + tail;
+        return "/orgs/" + organization.login + "/teams/" + getSlug() + tail;
     }
 
     /**

--- a/src/test/java/org/kohsuke/github/GHPullRequestTest.java
+++ b/src/test/java/org/kohsuke/github/GHPullRequestTest.java
@@ -193,9 +193,7 @@ public class GHPullRequestTest extends AbstractGitHubWireMockTest {
         assertThat("We should not eagerly load organizations for teams",
                 mockGitHub.getRequestCount() - baseRequestCount,
                 equalTo(1));
-        assertThat("Org should not be null",
-                p.getRequestedTeams().get(0).getOrganization(),
-                notNullValue());
+        assertThat("Org should not be null", p.getRequestedTeams().get(0).getOrganization(), notNullValue());
         assertThat("Request count should show that org was already present and thus did not refresh",
                 mockGitHub.getRequestCount() - baseRequestCount,
                 equalTo(1));

--- a/src/test/java/org/kohsuke/github/GHPullRequestTest.java
+++ b/src/test/java/org/kohsuke/github/GHPullRequestTest.java
@@ -193,12 +193,12 @@ public class GHPullRequestTest extends AbstractGitHubWireMockTest {
         assertThat("We should not eagerly load organizations for teams",
                 mockGitHub.getRequestCount() - baseRequestCount,
                 equalTo(1));
-        assertThat("Org should be queried for automatically if asked for",
+        assertThat("Org should not be null",
                 p.getRequestedTeams().get(0).getOrganization(),
                 notNullValue());
-        assertThat("Request count should show lazy load occurred",
+        assertThat("Request count should show that org was already present and thus did not refresh",
                 mockGitHub.getRequestCount() - baseRequestCount,
-                equalTo(2));
+                equalTo(1));
     }
 
     @Test

--- a/src/test/java/org/kohsuke/github/GHRepositoryTest.java
+++ b/src/test/java/org/kohsuke/github/GHRepositoryTest.java
@@ -658,7 +658,6 @@ public class GHRepositoryTest extends AbstractGitHubWireMockTest {
         assertThat(refs[0].getRef(), equalTo("refs/heads/main"));
     }
 
-
     @Test
     public void getPublicKey() throws Exception {
         GHRepository repo = getRepository(gitHub);

--- a/src/test/java/org/kohsuke/github/GHRepositoryTest.java
+++ b/src/test/java/org/kohsuke/github/GHRepositoryTest.java
@@ -662,7 +662,7 @@ public class GHRepositoryTest extends AbstractGitHubWireMockTest {
     public void getPublicKey() throws Exception {
         GHRepository repo = getRepository(gitHub);
         GHRepositoryPublicKey publicKey = repo.getPublicKey();
-        assertNotNull(publicKey);
+        assertThat(publicKey, notNullValue());
         assertThat(publicKey.getKey(), equalTo("test-key"));
         assertThat(publicKey.getKeyId(), equalTo("key-id"));
     }

--- a/src/test/java/org/kohsuke/github/GHRepositoryTest.java
+++ b/src/test/java/org/kohsuke/github/GHRepositoryTest.java
@@ -20,7 +20,6 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.kohsuke.github.GHVerification.Reason.*;
 

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_1450069_members_bitwiseman-50.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_1450069_members_bitwiseman-50.json
@@ -2,7 +2,7 @@
   "id": "4957aebb-5d50-4bd0-9940-eb1d306ce903",
   "name": "teams_1450069_members_bitwiseman",
   "request": {
-    "url": "/teams/1450069/members/bitwiseman",
+    "url": "/orgs/cloudbees/teams/team-infra-cloudbees-employees/memberships/bitwiseman",
     "method": "GET",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_1809126_members_bitwiseman-18.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_1809126_members_bitwiseman-18.json
@@ -2,7 +2,7 @@
   "id": "242ec43b-8f06-48af-bc39-3846b930a448",
   "name": "teams_1809126_members_bitwiseman",
   "request": {
-    "url": "/teams/1809126/members/bitwiseman",
+    "url": "/orgs/jenkinsci/teams/github-branch-source-plugin-developers/memberships/bitwiseman",
     "method": "GET",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_1882929_members_bitwiseman-66.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_1882929_members_bitwiseman-66.json
@@ -2,7 +2,7 @@
   "id": "285fc382-082e-418b-818a-bd0910f734b2",
   "name": "teams_1882929_members_bitwiseman",
   "request": {
-    "url": "/teams/1882929/members/bitwiseman",
+    "url": "/orgs/jenkins-infra/teams/copy-editors/memberships/bitwiseman",
     "method": "GET",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_1941826_members_bitwiseman-32.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_1941826_members_bitwiseman-32.json
@@ -2,7 +2,7 @@
   "id": "094e4d6c-83dc-46cb-9ad3-587e52fd380d",
   "name": "teams_1941826_members_bitwiseman",
   "request": {
-    "url": "/teams/1941826/members/bitwiseman",
+    "url": "/orgs/jenkins-inc/teams/engineering/memberships/bitwiseman",
     "method": "GET",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_1986920_members_bitwiseman-29.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_1986920_members_bitwiseman-29.json
@@ -2,7 +2,7 @@
   "id": "0dd3d927-287e-4a21-8977-d4f9d7d6cc49",
   "name": "teams_1986920_members_bitwiseman",
   "request": {
-    "url": "/teams/1986920/members/bitwiseman",
+    "url": "/orgs/jenkinsci/teams/workflow-cps-plugin-developers/memberships/bitwiseman",
     "method": "GET",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2070581_members_bitwiseman-42.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2070581_members_bitwiseman-42.json
@@ -2,7 +2,7 @@
   "id": "e22d18c0-2633-451c-a9cf-75bd37883fe1",
   "name": "teams_2070581_members_bitwiseman",
   "request": {
-    "url": "/teams/2070581/members/bitwiseman",
+    "url": "/orgs/cloudbees/teams/legacy-training-contributors/memberships/bitwiseman",
     "method": "GET",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2185547_members_bitwiseman-14.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2185547_members_bitwiseman-14.json
@@ -2,7 +2,7 @@
   "id": "301ee9c8-0469-4653-a4b6-3e3965388517",
   "name": "teams_2185547_members_bitwiseman",
   "request": {
-    "url": "/teams/2185547/members/bitwiseman",
+    "url": "/orgs/jenkinsci/teams/pipeline-model-definition-plugin-developers/memberships/bitwiseman",
     "method": "GET",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2188150_members_bitwiseman-58.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2188150_members_bitwiseman-58.json
@@ -2,7 +2,7 @@
   "id": "1a21b5fd-a5dc-4149-a06a-f1184cb2e2a7",
   "name": "teams_2188150_members_bitwiseman",
   "request": {
-    "url": "/teams/2188150/members/bitwiseman",
+    "url": "/orgs/jenkins-infra/teams/docs/memberships/bitwiseman",
     "method": "GET",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2278154_members_bitwiseman-60.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2278154_members_bitwiseman-60.json
@@ -2,7 +2,7 @@
   "id": "2a2981c6-834d-4cfd-8a8b-5d163d398316",
   "name": "teams_2278154_members_bitwiseman",
   "request": {
-    "url": "/teams/2278154/members/bitwiseman",
+    "url": "/orgs/jenkins-infra/teams/site-authors/memberships/bitwiseman",
     "method": "GET",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2300722_members_bitwiseman-7.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2300722_members_bitwiseman-7.json
@@ -2,7 +2,7 @@
   "id": "9bec5681-b961-4122-b399-39d654daf95a",
   "name": "teams_2300722_members_bitwiseman",
   "request": {
-    "url": "/teams/2300722/members/bitwiseman",
+    "url": "/orgs/jenkinsci/teams/declarative-rfc-reviewers/memberships/bitwiseman",
     "method": "GET",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2384898_members_bitwiseman-40.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2384898_members_bitwiseman-40.json
@@ -2,7 +2,7 @@
   "id": "95da1778-ddf4-4040-8777-5110e25a7615",
   "name": "teams_2384898_members_bitwiseman",
   "request": {
-    "url": "/teams/2384898/members/bitwiseman",
+    "url": "/orgs/cloudbees/teams/cje-reviewers/memberships/bitwiseman",
     "method": "GET",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2384906_members_bitwiseman-36.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2384906_members_bitwiseman-36.json
@@ -2,7 +2,7 @@
   "id": "f56cc484-a4ed-4467-908d-8bcd914912b2",
   "name": "teams_2384906_members_bitwiseman",
   "request": {
-    "url": "/teams/2384906/members/bitwiseman",
+    "url": "/orgs/cloudbees/teams/legacy-training-reviewers/memberships/bitwiseman",
     "method": "GET",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2478842_members_bitwiseman-16.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2478842_members_bitwiseman-16.json
@@ -2,7 +2,7 @@
   "id": "89727f43-cf60-42af-bf7f-c5016281db3b",
   "name": "teams_2478842_members_bitwiseman",
   "request": {
-    "url": "/teams/2478842/members/bitwiseman",
+    "url": "/orgs/jenkinsci/teams/jep-editors/memberships/bitwiseman",
     "method": "GET",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2510135_members_bitwiseman-62.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2510135_members_bitwiseman-62.json
@@ -2,7 +2,7 @@
   "id": "0a39104c-3aa9-4b48-a988-87fc0323775e",
   "name": "teams_2510135_members_bitwiseman",
   "request": {
-    "url": "/teams/2510135/members/bitwiseman",
+    "url": "/orgs/jenkins-infra/teams/hacktoberfest/memberships/bitwiseman",
     "method": "GET",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2658933_members_bitwiseman-64.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2658933_members_bitwiseman-64.json
@@ -2,7 +2,7 @@
   "id": "23b3d855-2f24-4554-8643-cb24e153b67d",
   "name": "teams_2658933_members_bitwiseman",
   "request": {
-    "url": "/teams/2658933/members/bitwiseman",
+    "url": "/orgs/jenkins-infra/teams/cn-jenkins-io/memberships/bitwiseman",
     "method": "GET",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2832516_members_bitwiseman-27.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2832516_members_bitwiseman-27.json
@@ -2,7 +2,7 @@
   "id": "01adc070-798a-4862-b0cf-6d96ca6ac5e2",
   "name": "teams_2832516_members_bitwiseman",
   "request": {
-    "url": "/teams/2832516/members/bitwiseman",
+    "url": "/orgs/jenkinsci/teams/jep-sponsors/memberships/bitwiseman",
     "method": "GET",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2832517_members_bitwiseman-21.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2832517_members_bitwiseman-21.json
@@ -2,7 +2,7 @@
   "id": "bd3f9695-f9e7-43e5-af7b-aeb5f71e352e",
   "name": "teams_2832517_members_bitwiseman",
   "request": {
-    "url": "/teams/2832517/members/bitwiseman",
+    "url": "/orgs/jenkinsci/teams/jep-bdfl-delegates/memberships/bitwiseman",
     "method": "GET",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2915408_members_bitwiseman-45.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2915408_members_bitwiseman-45.json
@@ -2,7 +2,7 @@
   "id": "b4fb1896-a01e-49a3-873b-2b8712decd5b",
   "name": "teams_2915408_members_bitwiseman",
   "request": {
-    "url": "/teams/2915408/members/bitwiseman",
+    "url": "/orgs/cloudbees/teams/pipeline-team/memberships/bitwiseman",
     "method": "GET",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2934265_members_bitwiseman-24.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2934265_members_bitwiseman-24.json
@@ -2,7 +2,7 @@
   "id": "f07c2ba7-3b7a-43df-ba10-8ac877892c1f",
   "name": "teams_2934265_members_bitwiseman",
   "request": {
-    "url": "/teams/2934265/members/bitwiseman",
+    "url": "/orgs/jenkinsci/teams/branch-api-plugin-developers/memberships/bitwiseman",
     "method": "GET",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_3023453_members_bitwiseman-12.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_3023453_members_bitwiseman-12.json
@@ -2,7 +2,7 @@
   "id": "2724fa0c-cdc2-4977-85de-0d3022e0680f",
   "name": "teams_3023453_members_bitwiseman",
   "request": {
-    "url": "/teams/3023453/members/bitwiseman",
+    "url": "/orgs/jenkinsci/teams/audit-log-plugin-developers/memberships/bitwiseman",
     "method": "GET",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_3136781_members_bitwiseman-48.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_3136781_members_bitwiseman-48.json
@@ -2,7 +2,7 @@
   "id": "ea7a1b90-f299-4265-a22d-ef286bb1229e",
   "name": "teams_3136781_members_bitwiseman",
   "request": {
-    "url": "/teams/3136781/members/bitwiseman",
+    "url": "/orgs/cloudbees/teams/certification-reviewers/memberships/bitwiseman",
     "method": "GET",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_3451996_members_bitwiseman-55.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_3451996_members_bitwiseman-55.json
@@ -2,7 +2,7 @@
   "id": "0e9309e5-a4ff-464d-9fff-eae6c4a28df2",
   "name": "teams_3451996_members_bitwiseman",
   "request": {
-    "url": "/teams/3451996/members/bitwiseman",
+    "url": "/orgs/hub4j-test-org/teams/dummy-team/memberships/bitwiseman",
     "method": "GET",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_496711_members_bitwiseman-9.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_496711_members_bitwiseman-9.json
@@ -2,7 +2,7 @@
   "id": "9e90f95d-7856-4183-9623-3187ae8ff3bd",
   "name": "teams_496711_members_bitwiseman",
   "request": {
-    "url": "/teams/496711/members/bitwiseman",
+    "url": "/orgs/jenkinsci/teams/scm-api-plugin-developers/memberships/bitwiseman",
     "method": "GET",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_663296_members_bitwiseman-69.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_663296_members_bitwiseman-69.json
@@ -2,7 +2,7 @@
   "id": "a7553907-7516-490b-be55-84fad2f47610",
   "name": "teams_663296_members_bitwiseman",
   "request": {
-    "url": "/teams/663296/members/bitwiseman",
+    "url": "/orgs/beautify-web/teams/owners/memberships/bitwiseman",
     "method": "GET",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_711073_members_bitwiseman-5.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_711073_members_bitwiseman-5.json
@@ -2,7 +2,7 @@
   "id": "9723ac0d-e1c9-462f-b1fc-f10acb89629d",
   "name": "teams_711073_members_bitwiseman",
   "request": {
-    "url": "/teams/711073/members/bitwiseman",
+    "url": "/orgs/jenkinsci/teams/script-security-plugin-developers/memberships/bitwiseman",
     "method": "GET",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_820404_members_bitwiseman-53.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_820404_members_bitwiseman-53.json
@@ -2,7 +2,7 @@
   "id": "be6df5bf-2958-4489-bf5c-ce8c65cb84d2",
   "name": "teams_820404_members_bitwiseman",
   "request": {
-    "url": "/teams/820404/members/bitwiseman",
+    "url": "/orgs/hub4j-test-org/teams/owners/memberships/bitwiseman",
     "method": "GET",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_879403_members_bitwiseman-38.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_879403_members_bitwiseman-38.json
@@ -2,7 +2,7 @@
   "id": "189224de-792d-45ba-993a-878171e9a63f",
   "name": "teams_879403_members_bitwiseman",
   "request": {
-    "url": "/teams/879403/members/bitwiseman",
+    "url": "/orgs/cloudbees/teams/team-documentation/memberships/bitwiseman",
     "method": "GET",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateTeam/mappings/teams_3531422_repos-5.json
+++ b/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateTeam/mappings/teams_3531422_repos-5.json
@@ -2,7 +2,7 @@
   "id": "9893d54e-bc2f-4246-ba25-b9c157b22845",
   "name": "teams_3531422_repos",
   "request": {
-    "url": "/teams/3531422/repos",
+    "url": "/orgs/hub4j-test-org/teams/create-team-test/repos",
     "method": "GET",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateTeamWithRepoAccess/mappings/teams_3501817_repos-5.json
+++ b/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateTeamWithRepoAccess/mappings/teams_3501817_repos-5.json
@@ -2,7 +2,7 @@
   "id": "97bad23b-9d25-4db2-8420-afbc40b450ac",
   "name": "teams_3501817_repos",
   "request": {
-    "url": "/teams/3501817/repos",
+    "url": "/orgs/hub4j-test-org/teams/create-team-test/repos",
     "method": "GET",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/testPullRequestTeamReviewRequests/mappings/teams_3451996-8.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/testPullRequestTeamReviewRequests/mappings/teams_3451996-8.json
@@ -2,7 +2,7 @@
   "id": "112cf6bd-f585-4cec-9ab9-f987a3704a98",
   "name": "teams_3451996",
   "request": {
-    "url": "/teams/3451996",
+    "url": "/orgs/hub4j-test-org/teams/dummy-team",
     "method": "GET",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/GHTeamTest/wiremock/testFetchChildTeams/mappings/teams_3451996_teams-4.json
+++ b/src/test/resources/org/kohsuke/github/GHTeamTest/wiremock/testFetchChildTeams/mappings/teams_3451996_teams-4.json
@@ -2,7 +2,7 @@
   "id": "c29c8c17-2529-4266-933e-2fba6569b235",
   "name": "teams_3451996_teams",
   "request": {
-    "url": "/teams/3451996/teams",
+    "url": "/orgs/hub4j-test-org/teams/dummy-team/teams",
     "method": "GET",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/GHTeamTest/wiremock/testFetchEmptyChildTeams/mappings/teams_3947450_teams-4.json
+++ b/src/test/resources/org/kohsuke/github/GHTeamTest/wiremock/testFetchEmptyChildTeams/mappings/teams_3947450_teams-4.json
@@ -2,7 +2,7 @@
   "id": "7a45d54e-c5da-4fd9-bb6a-121d5bc2381c",
   "name": "teams_3947450_teams",
   "request": {
-    "url": "/teams/3947450/teams",
+    "url": "/orgs/hub4j-test-org/teams/simple-team/teams",
     "method": "GET",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/GHTeamTest/wiremock/testSetDescription/mappings/teams_3451996-4.json
+++ b/src/test/resources/org/kohsuke/github/GHTeamTest/wiremock/testSetDescription/mappings/teams_3451996-4.json
@@ -2,7 +2,7 @@
   "id": "a8678668-24d0-4f75-b5a3-da720a764dd6",
   "name": "teams_3451996",
   "request": {
-    "url": "/teams/3451996",
+    "url": "/orgs/hub4j-test-org/teams/dummy-team",
     "method": "PATCH",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/GHTeamTest/wiremock/testSetDescription/mappings/teams_3451996-6.json
+++ b/src/test/resources/org/kohsuke/github/GHTeamTest/wiremock/testSetDescription/mappings/teams_3451996-6.json
@@ -2,7 +2,7 @@
   "id": "de9b6c26-1f63-4cc3-b4f6-6691f9bf180c",
   "name": "teams_3451996",
   "request": {
-    "url": "/teams/3451996",
+    "url": "/orgs/hub4j-test-org/teams/dummy-team",
     "method": "PATCH",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/GHTeamTest/wiremock/testSetPrivacy/mappings/teams_3451996-4.json
+++ b/src/test/resources/org/kohsuke/github/GHTeamTest/wiremock/testSetPrivacy/mappings/teams_3451996-4.json
@@ -2,7 +2,7 @@
   "id": "70263be8-4b8a-4f60-9e0a-da31aae7519f",
   "name": "teams_3451996",
   "request": {
-    "url": "/teams/3451996",
+    "url": "/orgs/hub4j-test-org/teams/dummy-team",
     "method": "PATCH",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/GHTeamTest/wiremock/testSetPrivacy/mappings/teams_3451996-6.json
+++ b/src/test/resources/org/kohsuke/github/GHTeamTest/wiremock/testSetPrivacy/mappings/teams_3451996-6.json
@@ -2,7 +2,7 @@
   "id": "51846d5d-d6ae-4a92-b608-ecaa62c3b73b",
   "name": "teams_3451996",
   "request": {
-    "url": "/teams/3451996",
+    "url": "/orgs/hub4j-test-org/teams/dummy-team",
     "method": "PATCH",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/GHTeamTest/wiremock/testlistMembersAdmin/mappings/teams_3451996_members-3.json
+++ b/src/test/resources/org/kohsuke/github/GHTeamTest/wiremock/testlistMembersAdmin/mappings/teams_3451996_members-3.json
@@ -2,7 +2,7 @@
   "id": "5ae66057-a096-48c4-a32c-b3baff1351d0",
   "name": "teams_3451996_members",
   "request": {
-    "url": "/teams/3451996/members?role=admin",
+    "url": "/orgs/hub4j-test-org/teams/dummy-team/members?role=admin",
     "method": "GET",
     "headers": {
       "Accept": {

--- a/src/test/resources/org/kohsuke/github/GHTeamTest/wiremock/testlistMembersNoMatch/mappings/teams_3451996_members-3.json
+++ b/src/test/resources/org/kohsuke/github/GHTeamTest/wiremock/testlistMembersNoMatch/mappings/teams_3451996_members-3.json
@@ -2,7 +2,7 @@
   "id": "c1db32bb-8a8c-4d7f-88d1-762949bdafa0",
   "name": "teams_3451996_members",
   "request": {
-    "url": "/teams/3451996/members?role=member",
+    "url": "/orgs/hub4j-test-org/teams/dummy-team/members?role=member",
     "method": "GET",
     "headers": {
       "Accept": {


### PR DESCRIPTION
# Description

https://github.blog/changelog/2022-02-22-sunset-notice-deprecated-teams-api-endpoints/

# Before submitting a PR:
We love getting PRs, but we hate asking people for the same basic changes every time.

- [ ] Push your changes to a branch other than `main`. Create your PR from that branch.
- [ ] Add JavaDocs and other comments
- [ ] Write tests that run and pass in CI. See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to capture snapshot data.
- [ ] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.

# When creating a PR: 

- [ ] Fill in the "Description" above.
- [ ] Enable "Allow edits from maintainers".
