### PR TITLE
feat: expose fields & extend content builder with commiter and author

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.kohsuke</groupId>
   <artifactId>cortexapps-github-api</artifactId>
-  <version>1.322</version>
+  <version>1.323</version>
   <name>GitHub API for Java</name>
   <url>https://github-api.kohsuke.org/</url>
   <description>GitHub API for Java</description>

--- a/src/main/java/org/kohsuke/github/GHCommit.java
+++ b/src/main/java/org/kohsuke/github/GHCommit.java
@@ -243,7 +243,7 @@ public class GHCommit {
     public static class Parent {
 
         /** The url. */
-        @SuppressFBWarnings(value = "UUF_UNUSED_FIELD", justification = "We don't provide it in API now")
+        @SuppressFBWarnings(value = "UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD", justification = "used in backend code")
         public String url;
 
         /** The sha. */

--- a/src/main/java/org/kohsuke/github/GHCommit.java
+++ b/src/main/java/org/kohsuke/github/GHCommit.java
@@ -244,10 +244,10 @@ public class GHCommit {
 
         /** The url. */
         @SuppressFBWarnings(value = "UUF_UNUSED_FIELD", justification = "We don't provide it in API now")
-        String url;
+        public String url;
 
         /** The sha. */
-        String sha;
+        public String sha;
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHContentBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHContentBuilder.java
@@ -19,6 +19,16 @@ public final class GHContentBuilder {
     private final Requester req;
     private String path;
 
+    private static final class UserInfo {
+        private final String name;
+        private final String email;
+
+        private UserInfo(String name, String email) {
+            this.name = name;
+            this.email = email;
+        }
+    }
+
     /**
      * Instantiates a new GH content builder.
      *
@@ -99,6 +109,34 @@ public final class GHContentBuilder {
      */
     public GHContentBuilder message(String commitMessage) {
         req.with("message", commitMessage);
+        return this;
+    }
+
+    /**
+     * Configures the author of this content.
+     *
+     * @param name
+     *            the name
+     * @param email
+     *            the email
+     * @return the gh commit builder
+     */
+    public GHContentBuilder author(String name, String email) {
+        req.with("author", new UserInfo(name, email));
+        return this;
+    }
+
+    /**
+     * Configures the committer of this content.
+     *
+     * @param name
+     *            the name
+     * @param email
+     *            the email
+     * @return the gh commit builder
+     */
+    public GHContentBuilder committer(String name, String email) {
+        req.with("committer", new UserInfo(name, email));
         return this;
     }
 

--- a/src/main/java/org/kohsuke/github/GitCommit.java
+++ b/src/main/java/org/kohsuke/github/GitCommit.java
@@ -241,7 +241,7 @@ public class GitCommit {
      * @return the parents
      */
     @SuppressFBWarnings(value = "EI_EXPOSE_REP", justification = "acceptable")
-    List<GHCommit.Parent> getParents() {
+    public List<GHCommit.Parent> getParents() {
         return parents;
     }
 


### PR DESCRIPTION
# Description

This PR:
- exposes some of the hidden fields needed for content update response
- extend content builder with committer & author information
