### PR TITLE
CET-18935 Adding security severity level for Code Scan alert

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.kohsuke</groupId>
   <artifactId>cortexapps-github-api</artifactId>
-  <version>1.324</version>
+  <version>1.325</version>
   <name>GitHub API for Java</name>
   <url>https://github-api.kohsuke.org/</url>
   <description>GitHub API for Java</description>

--- a/src/main/java/org/kohsuke/github/GHCodeScanningAlert.java
+++ b/src/main/java/org/kohsuke/github/GHCodeScanningAlert.java
@@ -231,7 +231,9 @@ public class GHCodeScanningAlert extends GHObject {
             return help;
         }
 
-        public String getSecuritySeverityLevel() { return security_severity_level; }
+        public String getSecuritySeverityLevel() {
+            return security_severity_level;
+        }
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHCodeScanningAlert.java
+++ b/src/main/java/org/kohsuke/github/GHCodeScanningAlert.java
@@ -166,6 +166,7 @@ public class GHCodeScanningAlert extends GHObject {
         private String full_description;
         private String[] tags;
         private String help;
+        private String security_severity_level;
 
         /**
          * Id of rule
@@ -229,6 +230,8 @@ public class GHCodeScanningAlert extends GHObject {
         public String getHelp() {
             return help;
         }
+
+        public String getSecuritySeverityLevel() { return security_severity_level; }
     }
 
     /**

--- a/src/test/java/org/kohsuke/github/GHCodeScanningAlertTest.java
+++ b/src/test/java/org/kohsuke/github/GHCodeScanningAlertTest.java
@@ -62,6 +62,7 @@ public class GHCodeScanningAlertTest extends AbstractGitHubWireMockTest {
         assertThat(rule.getId(), not((Object) null));
         assertThat(rule.getName(), not((Object) null));
         assertThat(rule.getSeverity(), not((Object) null));
+        assertThat(rule.getSecuritySeverityLevel(), not((Object) null));
 
         // Act - Search by filtering on alert status
         List<GHCodeScanningAlert> openAlerts = repo.listCodeScanningAlerts(GHCodeScanningAlertState.OPEN)


### PR DESCRIPTION
# Description

For CodeQL scans, Github has an attruibute security severity level which we should use over severity since it is what they use in the API

# Before submitting a PR:

- [ ] Changes must not break binary backwards compatibility. If you are unclear on how to make the change you think is needed while maintaining backward compatibility, [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [ ] Add JavaDocs and other comments as appropriate. Consider including links in comments to relevant documentation on https://docs.github.com/en/rest .  
- [ ] Add tests that cover any added or changed code. This generally requires capturing snapshot test data. See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
- [ ] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.
- [ ] Push your changes to a branch other than `main`. You will create your PR from that branch.

# When creating a PR: 

- [ ] Fill in the "Description" above with clear summary of the changes. This includes:
  - [ ] If this PR fixes one or more issues, include "Fixes #<issue number>" lines for each issue. 
  - [ ] Provide links to relevant documentation on https://docs.github.com/en/rest where possible.
- [ ] All lines of new code should be covered by tests as reported by code coverage. Any lines that are not covered must have PR comments explaining why they cannot be covered. For example, "Reaching this particular exception is hard and is not a particular common scenario."
- [ ] Enable "Allow edits from maintainers".
