### PR TITLE
Add Dependabot alert support

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -109,8 +109,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, test-8, test]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           java-version: 8
           distribution: 'zulu'

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.kohsuke</groupId>
   <artifactId>cortexapps-github-api</artifactId>
-  <version>1.329</version>
+  <version>1.330</version>
   <name>GitHub API for Java</name>
   <url>https://github-api.kohsuke.org/</url>
   <description>GitHub API for Java</description>

--- a/src/main/java/org/kohsuke/github/GHDependabotAlert.java
+++ b/src/main/java/org/kohsuke/github/GHDependabotAlert.java
@@ -1,0 +1,346 @@
+package org.kohsuke.github;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Date;
+
+/**
+ * Dependabot alert for a repository with a dependency affected by a security vulnerability.
+ *
+ * <a href="https://docs.github.com/en/rest/dependabot/alerts">Dependabot alerts API</a>
+ */
+@SuppressFBWarnings(value = { "UUF_UNUSED_FIELD" }, justification = "JSON API")
+public class GHDependabotAlert extends GHObject {
+    @JsonIgnore
+    private GHRepository owner;
+    private long number;
+    private String html_url;
+    private GHDependabotAlertState state;
+    private Dependency dependency;
+    private SecurityAdvisory security_advisory;
+    private SecurityVulnerability security_vulnerability;
+    private String created_at;
+    private String updated_at;
+    private String dismissed_at;
+    private GHUser dismissed_by;
+    private String dismissed_reason;
+    private String dismissed_comment;
+    private String fixed_at;
+    private String auto_dismissed_at;
+
+    GHDependabotAlert wrap(GHRepository owner) {
+        this.owner = owner;
+        return this;
+    }
+
+    /**
+     * Id/number of the alert.
+     *
+     * @return the id/number
+     * @see #getId()
+     */
+    public long getNumber() {
+        return number;
+    }
+
+    /**
+     * Id/number of the alert.
+     *
+     * @return the id/number
+     * @see #getNumber()
+     */
+    @Override
+    public long getId() {
+        return getNumber();
+    }
+
+    @Override
+    public URL getHtmlUrl() throws IOException {
+        return GitHubClient.parseURL(html_url);
+    }
+
+    /**
+     * State of alert.
+     *
+     * @return the state
+     */
+    public GHDependabotAlertState getState() {
+        return state;
+    }
+
+    /**
+     * Dependency that is affected by the vulnerability.
+     *
+     * @return the dependency
+     */
+    @SuppressFBWarnings(value = { "EI_EXPOSE_REP" }, justification = "Expected behavior")
+    public Dependency getDependency() {
+        return dependency;
+    }
+
+    /**
+     * Security advisory associated with the alert.
+     *
+     * @return the security advisory
+     */
+    @SuppressFBWarnings(value = { "EI_EXPOSE_REP" }, justification = "Expected behavior")
+    public SecurityAdvisory getSecurityAdvisory() {
+        return security_advisory;
+    }
+
+    /**
+     * Security vulnerability associated with the alert.
+     *
+     * @return the security vulnerability
+     */
+    @SuppressFBWarnings(value = { "EI_EXPOSE_REP" }, justification = "Expected behavior")
+    public SecurityVulnerability getSecurityVulnerability() {
+        return security_vulnerability;
+    }
+
+    /**
+     * Gets created at.
+     *
+     * @return the created at
+     */
+    public Date getCreatedAt() {
+        return GitHubClient.parseDate(created_at);
+    }
+
+    /**
+     * Gets updated at.
+     *
+     * @return the updated at
+     */
+    public Date getUpdatedAt() {
+        return GitHubClient.parseDate(updated_at);
+    }
+
+    /**
+     * Time when alert was dismissed. Non-null when {@link #getState()} is DISMISSED.
+     *
+     * @return the time
+     */
+    public Date getDismissedAt() {
+        return GitHubClient.parseDate(dismissed_at);
+    }
+
+    /**
+     * User that dismissed the alert. Non-null when {@link #getState()} is DISMISSED.
+     *
+     * @return the user
+     */
+    @SuppressFBWarnings(value = { "EI_EXPOSE_REP" }, justification = "Expected behavior")
+    public GHUser getDismissedBy() {
+        return dismissed_by;
+    }
+
+    /**
+     * Reason for dismissal. Can be 'fix_started', 'inaccurate', 'no_bandwidth', 'not_used', 'tolerable_risk'.
+     *
+     * @return the reason
+     */
+    public String getDismissedReason() {
+        return dismissed_reason;
+    }
+
+    /**
+     * Optional comment associated with the dismissal.
+     *
+     * @return the comment
+     */
+    public String getDismissedComment() {
+        return dismissed_comment;
+    }
+
+    /**
+     * Dependency affected by the vulnerability.
+     */
+    @SuppressFBWarnings(value = { "UWF_UNWRITTEN_FIELD" }, justification = "JSON API")
+    public static class Dependency {
+        @JsonProperty("package")
+        private Package pkg;
+        private String manifest_path;
+        private String scope;
+
+        /**
+         * The package affected by the vulnerability.
+         *
+         * @return the package
+         */
+        public Package getPackage() {
+            return pkg;
+        }
+
+        /**
+         * Path to the manifest file that declares the dependency.
+         *
+         * @return the manifest path
+         */
+        public String getManifestPath() {
+            return manifest_path;
+        }
+
+        /**
+         * Scope of the dependency (runtime or development).
+         *
+         * @return the scope
+         */
+        public String getScope() {
+            return scope;
+        }
+    }
+
+    /**
+     * A package affected by a vulnerability.
+     */
+    @SuppressFBWarnings(value = { "UWF_UNWRITTEN_FIELD" }, justification = "JSON API")
+    public static class Package {
+        private String ecosystem;
+        private String name;
+
+        /**
+         * The package ecosystem (e.g., npm, pip, maven).
+         *
+         * @return the ecosystem
+         */
+        public String getEcosystem() {
+            return ecosystem;
+        }
+
+        /**
+         * The package name.
+         *
+         * @return the name
+         */
+        public String getName() {
+            return name;
+        }
+    }
+
+    /**
+     * Security advisory associated with a Dependabot alert.
+     */
+    @SuppressFBWarnings(value = { "UWF_UNWRITTEN_FIELD" }, justification = "JSON API")
+    public static class SecurityAdvisory {
+        private String ghsa_id;
+        private String cve_id;
+        private String summary;
+        private String description;
+        private String severity;
+
+        /**
+         * GitHub Security Advisory ID.
+         *
+         * @return the GHSA ID
+         */
+        public String getGhsaId() {
+            return ghsa_id;
+        }
+
+        /**
+         * CVE ID for the advisory, if available.
+         *
+         * @return the CVE ID
+         */
+        public String getCveId() {
+            return cve_id;
+        }
+
+        /**
+         * Short summary of the advisory.
+         *
+         * @return the summary
+         */
+        public String getSummary() {
+            return summary;
+        }
+
+        /**
+         * Full description of the advisory.
+         *
+         * @return the description
+         */
+        public String getDescription() {
+            return description;
+        }
+
+        /**
+         * Severity of the advisory (critical, high, medium, low).
+         *
+         * @return the severity
+         */
+        public String getSeverity() {
+            return severity;
+        }
+    }
+
+    /**
+     * Security vulnerability details.
+     */
+    @SuppressFBWarnings(value = { "UWF_UNWRITTEN_FIELD" }, justification = "JSON API")
+    public static class SecurityVulnerability {
+        @JsonProperty("package")
+        private Package pkg;
+        private String severity;
+        private String vulnerable_version_range;
+        private PatchedVersion first_patched_version;
+
+        /**
+         * The package affected by this vulnerability.
+         *
+         * @return the package
+         */
+        public Package getPackage() {
+            return pkg;
+        }
+
+        /**
+         * Severity of the vulnerability (critical, high, medium, low).
+         *
+         * @return the severity
+         */
+        public String getSeverity() {
+            return severity;
+        }
+
+        /**
+         * Version range affected by the vulnerability.
+         *
+         * @return the vulnerable version range
+         */
+        public String getVulnerableVersionRange() {
+            return vulnerable_version_range;
+        }
+
+        /**
+         * First patched version that fixes the vulnerability.
+         *
+         * @return the first patched version
+         */
+        public PatchedVersion getFirstPatchedVersion() {
+            return first_patched_version;
+        }
+    }
+
+    /**
+     * A patched version identifier.
+     */
+    @SuppressFBWarnings(value = { "UWF_UNWRITTEN_FIELD" }, justification = "JSON API")
+    public static class PatchedVersion {
+        private String identifier;
+
+        /**
+         * The version identifier.
+         *
+         * @return the identifier
+         */
+        public String getIdentifier() {
+            return identifier;
+        }
+    }
+}

--- a/src/main/java/org/kohsuke/github/GHDependabotAlertState.java
+++ b/src/main/java/org/kohsuke/github/GHDependabotAlertState.java
@@ -1,0 +1,23 @@
+package org.kohsuke.github;
+
+/**
+ * What is the current state of the Dependabot Alert
+ */
+public enum GHDependabotAlertState {
+    /**
+     * Alert is open and still an active issue.
+     */
+    OPEN,
+    /**
+     * Alert has been manually dismissed by a user.
+     */
+    DISMISSED,
+    /**
+     * Issue that caused the alert has been fixed.
+     */
+    FIXED,
+    /**
+     * Alert has been automatically dismissed by Dependabot.
+     */
+    AUTO_DISMISSED,
+}

--- a/src/main/java/org/kohsuke/github/GHDependabotAlertsIterable.java
+++ b/src/main/java/org/kohsuke/github/GHDependabotAlertsIterable.java
@@ -1,0 +1,45 @@
+package org.kohsuke.github;
+
+import java.util.Iterator;
+
+import javax.annotation.Nonnull;
+
+class GHDependabotAlertsIterable extends PagedIterable<GHDependabotAlert> {
+    private final GHRepository owner;
+    private final GitHubRequest request;
+    private GHDependabotAlert[] result;
+
+    GHDependabotAlertsIterable(GHRepository owner, GitHubRequest request) {
+        this.owner = owner;
+        this.request = request;
+    }
+
+    @Nonnull
+    @Override
+    public PagedIterator<GHDependabotAlert> _iterator(int pageSize) {
+        return new PagedIterator<>(
+                adapt(GitHubPageIterator
+                        .create(owner.root().getClient(), GHDependabotAlert[].class, request, pageSize)),
+                null);
+    }
+
+    protected Iterator<GHDependabotAlert[]> adapt(final Iterator<GHDependabotAlert[]> base) {
+        return new Iterator<GHDependabotAlert[]>() {
+            public boolean hasNext() {
+                return base.hasNext();
+            }
+
+            public GHDependabotAlert[] next() {
+                GHDependabotAlert[] v = base.next();
+                if (result == null) {
+                    result = v;
+                }
+
+                for (GHDependabotAlert alert : result) {
+                    alert.wrap(owner);
+                }
+                return result;
+            }
+        };
+    }
+}

--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -3544,6 +3544,54 @@ public class GHRepository extends GHObject {
                 .wrap(this);
     }
 
+    /**
+     * Lists the Dependabot alerts for this repository.
+     *
+     * @return the paged iterable
+     */
+    public PagedIterable<GHDependabotAlert> listDependabotAlerts() {
+        return listDependabotAlerts(Collections.emptyMap());
+    }
+
+    /**
+     * Lists the Dependabot alerts for this repository filtered on the alert state.
+     *
+     * @param state
+     *            state of the alert
+     * @return the paged iterable
+     */
+    public PagedIterable<GHDependabotAlert> listDependabotAlerts(GHDependabotAlertState state) {
+        return listDependabotAlerts(Collections.singletonMap("state", state.name().toLowerCase()));
+    }
+
+    /**
+     * Lists the Dependabot alerts for this repository filtered based on passed query params.
+     *
+     * @param filters
+     *            query params passed to request
+     * @return the paged iterable
+     */
+    public PagedIterable<GHDependabotAlert> listDependabotAlerts(Map<String, Object> filters) {
+        return new GHDependabotAlertsIterable(this,
+                root().createRequest().withUrlPath(getApiTailUrl("dependabot/alerts")).with(filters).build());
+    }
+
+    /**
+     * Get Dependabot alert by number.
+     *
+     * @param number
+     *            number of the Dependabot alert
+     * @return the Dependabot alert
+     * @throws IOException
+     *             the io exception
+     */
+    public GHDependabotAlert getDependabotAlert(long number) throws IOException {
+        return root().createRequest()
+                .withUrlPath(getApiTailUrl("dependabot/alerts"), String.valueOf(number))
+                .fetch(GHDependabotAlert.class)
+                .wrap(this);
+    }
+
     private <T> T downloadArchive(@Nonnull String type,
             @CheckForNull String ref,
             @Nonnull InputStreamFunction<T> streamFunction) throws IOException {


### PR DESCRIPTION
## Summary
Add `GHDependabotAlert` support to the library, following the same pattern as `GHCodeScanningAlert` and `GHSecretScanningAlert`.

Additionally, bump the "setup-java" and "checkout" actions to v4 -- the v2 version is deprecated and causes build errors in CI (as seen in commit [22872d3](https://github.com/cortexapps/github-api/pull/36/commits/22872d34aee415e712d4f59009d668ee7771cb45))

## New classes
- `GHDependabotAlert` — Main alert class with nested `Dependency`, `SecurityAdvisory`, `SecurityVulnerability`, `Package`, `PatchedVersion`
- `GHDependabotAlertState` — `OPEN`, `DISMISSED`, `FIXED`, `AUTO_DISMISSED`
- `GHDependabotAlertsIterable` — Paginated iteration with owner wrapping

## New GHRepository methods
- `listDependabotAlerts()` / `listDependabotAlerts(state)` / `listDependabotAlerts(filters)`
- `getDependabotAlert(number)`

## Endpoint
`GET /repos/{owner}/{repo}/dependabot/alerts`

## Context
Needed by brain-backend ([CET-24466](https://cortex1.atlassian.net/browse/CET-24466)) to fetch Dependabot alerts via REST API instead of GraphQL `vulnerabilityAlerts`, which silently returns empty on GHES instances with restricted token permissions.

[CET-24466]: https://cortex1.atlassian.net/browse/CET-24466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ